### PR TITLE
Update server.rb

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,7 +23,7 @@ ssh_hosts = []
 
 search_string = 'ossec:[* TO *]'
 search_string << " AND chef_environment:#{node['ossec']['server_env']}" if node['ossec']['server_env']
-search_string << " AND NOT role:#{node['ossec']['server_role']} AND NOT fqdn:#{node['fqdn']}"
+search_string << " AND NOT (role:#{node['ossec']['server_role']} AND fqdn:#{node['fqdn']})"
 
 search(:node, search_string) do |n|
   ssh_hosts << n['ipaddress'] if n['keys']


### PR DESCRIPTION
In chef 12 this query give me a error

```
 knife search node "ossec:[* TO *] AND chef_environment:server AND NOT role:ossec_server AND NOT fqdn:manager.xxx.com"
ERROR: knife search failed: invalid search query: 'ossec:[* TO *] AND chef_environment:server AND NOT role:ossec_server AND NOT fqdn:manager.yokatan.com'
```
But if i change the query 

```
knife search node "ossec:[* TO *] AND chef_environment:server AND NOT (role:ossec_server OR fqdn:manager.xxx.com)"
1 items found

Node Name:   agent.xxx.com
Environment: server
FQDN:        agent.xxx.com
IP:          172.16.141.142
Run List:    role[ossec_client]
Roles:       ossec_client
Recipes:     ossec::client, ossec::_common
Platform:    centos 6.7
Tags:
```
work nice.